### PR TITLE
Optimize packet reader

### DIFF
--- a/lib/protocol/hpacket.js
+++ b/lib/protocol/hpacket.js
@@ -3,6 +3,8 @@ import { PacketInfoManager } from "../services/packetinfo/packetinfomanager.js";
 import util from "util";
 
 export class HPacket {
+    static TEXT_DECODER = new TextDecoder('utf8');
+
     #isEdited = false;
     #packetInBytes;
     #readIndex = 6;
@@ -257,7 +259,7 @@ export class HPacket {
         }
 
         if(Number.isInteger(index) && index < this.#packetInBytes.length - 1) {
-            return Buffer.from(this.#packetInBytes).readInt16BE(index);
+            return (this.#packetInBytes[index + 1]) | (this.#packetInBytes[index] << 8);
         }
 
         throw new Error("Invalid argument(s) passed or read index out of bounds");
@@ -270,7 +272,7 @@ export class HPacket {
         }
 
         if(Number.isInteger(index) && index < this.#packetInBytes.length - 1) {
-            return Buffer.from(this.#packetInBytes).readUInt16BE(index);
+            return (this.#packetInBytes[index + 1]) | (this.#packetInBytes[index] << 8);
         }
 
         throw new Error("Invalid argument(s) passed or read index out of bounds");
@@ -287,7 +289,10 @@ export class HPacket {
         }
 
         if(Number.isInteger(index) && index < this.#packetInBytes.length - 3) {
-            return Buffer.from(this.#packetInBytes).readInt32BE(index);
+            return (this.#packetInBytes[index + 3]) |
+                (this.#packetInBytes[index + 2] << 8) |
+                (this.#packetInBytes[index + 1] << 16) |
+                (this.#packetInBytes[index] << 24);
         }
 
         throw new Error("Invalid argument(s) passed or read index out of bounds");
@@ -335,11 +340,7 @@ export class HPacket {
             }
 
             if(Number.isInteger(index) && index < this.#packetInBytes.length + 1 - length) {
-                let newBytes = new Uint8Array(length);
-                for(let i = 0; i < length; i++) {
-                    newBytes[i] = this.#packetInBytes[i + index];
-                }
-                return newBytes;
+                return new Uint8Array(length, index, length);
             }
         }
 
@@ -353,7 +354,14 @@ export class HPacket {
         }
 
         if(Number.isInteger(index) && index < this.#packetInBytes.length - 7) {
-            return Number(Buffer.from(this.#packetInBytes).readBigInt64BE(index));
+            return (this.#packetInBytes[index + 7]) |
+                (this.#packetInBytes[index + 6] << 8) |
+                (this.#packetInBytes[index + 5] << 16) |
+                (this.#packetInBytes[index + 4] << 24) 
+                (this.#packetInBytes[index + 3] << 32) |
+                (this.#packetInBytes[index + 2] << 40) |
+                (this.#packetInBytes[index + 1] << 48) |
+                (this.#packetInBytes[index] << 52);
         }
 
         throw new Error("Invalid argument(s) passed or read index out of bounds");
@@ -378,7 +386,7 @@ export class HPacket {
             let length = this.readUShort(index);
             index += 2;
             if(index < this.#packetInBytes.length + 1 - length) {
-                return Buffer.from(this.#packetInBytes).toString(charset, index, index + length);
+                return HPacket.TEXT_DECODER.decode(new Uint8Array(this.#packetInBytes.buffer, index, length));
             }
         }
 
@@ -404,7 +412,7 @@ export class HPacket {
             let length = this.readInteger(index);
             index += 4;
             if(index < this.#packetInBytes.length + 1 - length) {
-                return Buffer.from(this.#packetInBytes).toString(charset, index, index + length);
+                return HPacket.TEXT_DECODER.decode(new Uint8Array(this.#packetInBytes.buffer, index, length));
             }
         }
 


### PR DESCRIPTION
Current implementation is very inefficient because it constructs a new `Buffer` for every read operation. This PR addresses that.
Example of parsing `Objects` packet with `HFloorItem.parse`.

**Before**
![image](https://github.com/WiredSpast/G-Node/assets/74633542/748819ee-d37d-40c9-988b-81d268a7605b)

**After**
![image](https://github.com/WiredSpast/G-Node/assets/74633542/809db053-471b-4ae0-8349-b246c75f5d69)

**Notes**
I have not properly tested signed and unsigned correctness.