### PR TITLE
Minor typo in the HPacket inspection string

### DIFF
--- a/lib/protocol/hpacket.js
+++ b/lib/protocol/hpacket.js
@@ -15,7 +15,7 @@ export class HPacket {
         return    `${indent}HPacket {\n`
             + `${indent}  headerId(): ${util.inspect(this.headerId(), {colors: true})}\n`
             + `${indent}  isEdited(): ${util.inspect(this.#isEdited, {colors: true})}\n`
-            + `${indent}  getBytes(): ${util.inspect(this.#packetInBytes, {colors: true, maxArrayLength: 0})}\n`
+            + `${indent}  toBytes(): ${util.inspect(this.#packetInBytes, {colors: true, maxArrayLength: 0})}\n`
             + `${indent}  readIndex: ${util.inspect(this.#readIndex, {colors: true})}\n`
             + `${this.#identifier != null ? `${indent}  identifier: ${util.inspect(this.#identifier, {colors: true})}\n` : ''}`
             + `${this.#identifierDirection != null ? `${indent}  identifierDirection: HDirection.\x1b[36m${HDirection.identify(this.#identifierDirection)}\x1b[0m\n` : ''}`


### PR DESCRIPTION
The string shows a `getBytes()` method but its actually called `toBytes()`.