### PR TITLE
Improve `read` type-safety and add `intercept` method

### DIFF
--- a/lib/extension/extension.d.ts
+++ b/lib/extension/extension.d.ts
@@ -1,9 +1,9 @@
-import {HPacket} from "../protocol/hpacket";
-import {HDirection} from "../protocol/hdirection";
-import {HMessage} from "../protocol/hmessage";
-import {ExtensionInfo} from "./extensioninfo";
-import {HClient} from "../protocol/hclient";
-import {PacketInfoManager} from "../services/packetinfo/packetinfomanager";
+import { HPacket } from "../protocol/hpacket";
+import { HDirection } from "../protocol/hdirection";
+import { HMessage } from "../protocol/hmessage";
+import { ExtensionInfo } from "./extensioninfo";
+import { HClient } from "../protocol/hclient";
+import { PacketInfoManager } from "../services/packetinfo/packetinfomanager";
 import { HostInfo } from "../misc/hostinfo";
 
 export class Extension {
@@ -28,6 +28,14 @@ export class Extension {
      * @return success or failure
      */
     sendToServer(packet: HPacket): boolean;
+
+    /**
+     * Register a listener on a specific packet type by header ID, name or hash
+     * @param direction ToClient or ToServer
+     * @param headerNameOrHash The packet header ID, name or hash
+     * @param messageListener The callback
+    */
+    intercept(direction: HDirection, headerIdOrNameOrHash: string | number, messageListener: (hMessage: HMessage) => void): void;
 
     /**
      * Register a listener on a specific packet type by name or hash

--- a/lib/extension/extension.js
+++ b/lib/extension/extension.js
@@ -344,6 +344,19 @@ export class Extension extends EventEmitter {
         this.interceptByHeaderId(direction, -1, messageListener);
     }
 
+    intercept(direction, headerIdOrNameOrHash, messageListener) {
+        if(!(direction === HDirection.TOCLIENT || direction === HDirection.TOSERVER) || !Number.isInteger(headerId) || typeof(messageListener) !== "function") {
+            throw new Error("Invalid arguments passed");
+        }
+
+        if(Number.isInteger(headerIdOrNameOrHash)) {
+            this.interceptByHeaderId(direction, headerIdOrNameOrHash, messageListener);
+            return;
+        }
+
+        this.interceptByNameOrHash(direction, headerIdOrNameOrHash, messageListener);
+    }
+
     interceptByHeaderId(direction, headerId, messageListener) {
         if(!(direction === HDirection.TOCLIENT || direction === HDirection.TOSERVER) || !Number.isInteger(headerId) || typeof(messageListener) !== "function") {
             throw new Error("Invalid arguments passed");

--- a/lib/protocol/hpacket.d.ts
+++ b/lib/protocol/hpacket.d.ts
@@ -1,6 +1,31 @@
 import { HDirection } from "./hdirection";
 import { PacketInfoManager } from "../services/packetinfo/packetinfomanager";
 
+type PacketValue = {
+    b: number;
+    i: number;
+    s: number;
+    u: number;
+    l: bigint;
+    d: number;
+    f: number;
+    B: boolean;
+    S: string;
+};
+
+/*
+* This type is used to get the values of the packet in the order of the structure
+* Example:
+* packet.read('bS') -> [number, string]
+* packet.read('bSf') -> [number, string, number]
+* packet.read('bSfB') -> [number, string, number, boolean]
+*/
+type PacketValueTuple<T extends string, U extends unknown[] = []> = T extends `${infer First}${infer Rest}`
+    ? First extends keyof PacketValue
+    ? PacketValueTuple<Rest, [...U, PacketValue[First]]>
+    : U
+    : U;
+
 export class HPacket {
     constructor(bytes: Uint8Array);
     constructor(packet: HPacket);
@@ -163,7 +188,7 @@ export class HPacket {
      * S: string
      * @param structure Structure string to read
      */
-    read(structure: string): any[];
+    read<T extends string>(structure: T): PacketValueTuple<T>
 
     /**
      * Replace boolean by value
@@ -455,7 +480,7 @@ export class HPacket {
      * @param objects Array of objects to insert
      * @param structure String of objects structure
      */
-    insert(index:number, structure: string, ...objects: any[]): this;
+    insert(index: number, structure: string, ...objects: any[]): this;
 
 
     /**


### PR DESCRIPTION
Added a type to infer the values return of the packet in the order of the structure

Example:
packet.read('bS') -> [number, string]
packet.read('bSf') -> [number, string, number]
packet.read('bSfB') -> [number, string, number, boolean]

Also, I've added a new method to intercept packets in a more easy way
